### PR TITLE
Add Error field to the PageResult object

### DIFF
--- a/NetTelegraph/Result/PageResult.cs
+++ b/NetTelegraph/Result/PageResult.cs
@@ -20,7 +20,13 @@ namespace NetTelegraph.Result
         /// <summary>
         /// Result of the query.
         /// </summary>
-        [JsonProperty("result", Required = Required.Always)]
+        [JsonProperty("result", Required = Required.Default)]
         public Page Result { get; set; }
+
+        /// <summary>
+        /// Error message.
+        /// </summary>
+        [JsonProperty("error", Required = Required.Default)]
+        public string Error { get; set; }
     }
 }


### PR DESCRIPTION
In case of an unsuccessful `createPage` request the error is explained in the error field. 
I added this filed.